### PR TITLE
.github: workflows: Remove unsupported Python version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,6 @@ jobs:
           - scobc-a1-sample/samples/sysmon
           - scobc-a1-sample/samples/i2c
         python-version:
-          - '3.10'
-          - '3.11'
           - '3.12'
           - '3.13'
         os:


### PR DESCRIPTION
From 043bb58 in Zephyr upstream, the minimum supported version of Python has been updated from 3.10 to 3.12. Therefore, remove Python 3.10 and 3.11 from our build tests.