### PR TITLE
drivers: flash: Add Space Cubics QSPI NOR driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,4 @@
 add_subdirectory(drivers/misc/sc_fpga)
 add_subdirectory(drivers/i2c)
 add_subdirectory(drivers/can)
+add_subdirectory(drivers/flash)

--- a/Kconfig
+++ b/Kconfig
@@ -4,3 +4,4 @@
 rsource "drivers/misc/sc_fpga/Kconfig"
 rsource "drivers/i2c/Kconfig"
 rsource "drivers/can/Kconfig"
+rsource "drivers/flash/Kconfig"

--- a/boards/shields/scobc_a1_dev/scobc_a1_dev.overlay
+++ b/boards/shields/scobc_a1_dev/scobc_a1_dev.overlay
@@ -124,5 +124,81 @@
 			xlnx,num-ss-bits = <0x3>;
 			xlnx,num-transfer-bits = <0x8>;
 		};
+
+		qspi_cfg: qspi@40000000 {
+			compatible = "sc,qspi-a1";
+			reg = <0x40000000 0x1000>;
+			interrupts = <2 0>;
+			cpol = <0>;
+			cpha = <0>;
+			spiclk-div = <0>;
+			status = "okay";
+
+			cfg_flash0: cfgmem0 {
+				compatible = "sc,qspi-nor-a1";
+				mem-no = <0>;
+				size = <DT_SIZE_M(32)>;
+				jedec-id = [01 60 19];
+				sc-sysreg = <&sysreg>;
+				status = "okay";
+			};
+
+			cfg_flash1: cfgmem1 {
+				compatible = "sc,qspi-nor-a1";
+				mem-no = <1>;
+				size = <DT_SIZE_M(32)>;
+				jedec-id = [01 60 19];
+				sc-sysreg = <&sysreg>;
+				status = "okay";
+			};
+		};
+
+		qspi_data: qspi@40100000 {
+			compatible = "sc,qspi-a1";
+			reg = <0x40100000 0x1000>;
+			interrupts = <3 0>;
+			cpol = <0>;
+			cpha = <0>;
+			spiclk-div = <0>;
+			status = "okay";
+
+			data_flash0: flash0 {
+				compatible = "sc,qspi-nor-a1";
+				mem-no = <0>;
+				size = <DT_SIZE_M(32)>;
+				jedec-id = [01 60 19];
+				status = "okay";
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					storage_partition: partition@0 {
+						label = "storage";
+						reg = <0x0 DT_SIZE_M(32)>;
+					};
+				};
+			};
+
+			data_flash1: flash1 {
+				compatible = "sc,qspi-nor-a1";
+				mem-no = <1>;
+				size = <DT_SIZE_M(32)>;
+				jedec-id = [01 60 19];
+				status = "okay";
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					storage_partition1: partition@0 {
+						label = "storage1";
+						reg = <0x0 DT_SIZE_M(32)>;
+					};
+				};
+			};
+		};
 	};
 };

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_FLASH)
+  zephyr_library_amend()
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/flash)
+  zephyr_library_sources_ifdef(CONFIG_SC_QSPI_NOR_A1 flash_sc_qspi_a1.c)
+endif()

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if FLASH
+
+rsource "Kconfig.sc"
+
+endif

--- a/drivers/flash/Kconfig.sc
+++ b/drivers/flash/Kconfig.sc
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig SC_QSPI_NOR_A1
+	bool "Space Cubics SC-OBC Module A1 QSPI NOR flash driver"
+	default y
+	depends on DT_HAS_SC_QSPI_NOR_A1_ENABLED
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_EXPLICIT_ERASE
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_JESD216
+	help
+	  Enable support for Space Cubics SC-OBC Module A1 QSPI NOR flash driver.
+
+if SC_QSPI_NOR_A1
+
+config SC_QSPI_NOR_A1_IDLE_TIMEOUT_MS
+	int "Timeout duration for waiting until the QSPI Bus becomes idle.[ms]"
+	default 100
+	help
+	  Timeout duration for waiting until the QSPI Bus becomes idle. [ms]
+
+config SC_QSPI_NOR_A1_SLEEP_ERASE_MS
+	int "Poll interval for erase [ms]"
+	default 50
+	range 1 800
+	help
+	  How long to sleep between status register polls during erase.
+	  Typical time for 4KB erase command for the NOR flash S25FL256L is 50ms.
+
+config SC_QSPI_NOR_A1_ERASE_TIMEOUT_MS
+	int "Total timeout for erase operation [ms]"
+	default 1000
+	range 1 2000
+	help
+	  Maximum time to wait for an erase operation to complete while polling WIP.
+	  The required time depends on the flash device and erase command (sector/block).
+	  Typical time is 270ms for 64KB erase command, max 725ms for the NOR flash S25FL256L.
+	  Set this higher than the datasheet maximum to account for system jitter and margins.
+
+config SC_QSPI_NOR_A1_SLEEP_WRITE_US
+	int "Poll interval for erase [us]"
+	default 300
+	range 1 1200
+	help
+	  How long to sleep between status register polls during page programming.
+
+config SC_QSPI_NOR_A1_WRITE_TIMEOUT_US
+	int "Total timeout for write (page program) [us]"
+	default 2000
+	range 1 3000
+	help
+	  Maximum time to wait for a page program to complete.
+	  Typical time is 300us, max 1.2ms for the NOR flash S25FL256L.
+
+endif

--- a/drivers/flash/flash_sc_qspi_a1.c
+++ b/drivers/flash/flash_sc_qspi_a1.c
@@ -1,0 +1,1070 @@
+/*
+ * Copyright (c) 2025 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "flash_sc_qspi_a1.h"
+#include "spi_nor.h"
+#include "jesd216.h"
+
+LOG_MODULE_REGISTER(flash_sc_qspi_a1, CONFIG_FLASH_LOG_LEVEL);
+
+/* Offsets */
+#define SCQSPI_A1_ACR_OFFSET    0x0000 /* Access Control */
+#define SCQSPI_A1_TDR_OFFSET    0x0004 /* TX Data */
+#define SCQSPI_A1_RDR_OFFSET    0x0008 /* RX Data */
+#define SCQSPI_A1_ASR_OFFSET    0x000C /* Access Status */
+#define SCQSPI_A1_FIFOSR_OFFSET 0x0010 /* FIFO Status */
+#define SCQSPI_A1_FIFORR_OFFSET 0x0014 /* FIFO Reset */
+#define SCQSPI_A1_ISR_OFFSET    0x0020 /* Interrupt Status */
+#define SCQSPI_A1_IER_OFFSET    0x0024 /* Interrupt Enable */
+#define SCQSPI_A1_CCR_OFFSET    0x0030 /* Clock Control */
+
+/* Access Control Register (ACR) Bits */
+#define SCQSPI_A1_ACR_SS_OFF    0x00
+#define SCQSPI_A1_ACR_SS1       BIT(0)
+#define SCQSPI_A1_ACR_SS2       BIT(1)
+#define SCQSPI_A1_ACR_MODE_QUAD BIT(17)
+
+/* QSPI Interrupt Status Register */
+#define SCQSPI_A1_SPICTRLDN BIT(0)
+
+/* QSPI Interrupt Enable Register */
+#define SCQSPI_A1_TXFIFOUTHEMB BIT(26)
+#define SCQSPI_A1_TXFIFOOVFEMB BIT(25)
+#define SCQSPI_A1_TXFIFOUDFEMB BIT(24)
+#define SCQSPI_A1_RXFIFOOTHEMB BIT(18)
+#define SCQSPI_A1_RXFIFOOVFEMB BIT(17)
+#define SCQSPI_A1_RXFIFOUDFEMB BIT(16)
+#define SCQSPI_A1_SPIBUSYDNEMB BIT(0)
+#define SCQSPI_A1_IER_ALL                                                                          \
+	(SCQSPI_A1_TXFIFOUTHEMB | SCQSPI_A1_TXFIFOOVFEMB | SCQSPI_A1_TXFIFOUDFEMB |                \
+	 SCQSPI_A1_RXFIFOOTHEMB | SCQSPI_A1_RXFIFOOVFEMB | SCQSPI_A1_RXFIFOUDFEMB |                \
+	 SCQSPI_A1_SPIBUSYDNEMB)
+
+/* Clock Control Register (CCR) Shifts */
+#define SCQSPI_A1_CCR_SCKPOL_SHIFT 20U
+#define SCQSPI_A1_CCR_SCKPHA_SHIFT 16U
+#define SCQSPI_A1_CCR_SCKDIV_SHIFT 0U
+
+/* Driver Constants */
+#define SCQSPI_A1_RX_FIFO_MAX_BYTE      16U
+#define SCQSPI_A1_PAGE_BUFFER_BYTE      256U
+/*
+ * Since the current driver implementation only supports a fixed latency of
+ * 8 dummy cycles, this value is hardcoded via #define. It is not exposed via
+ * Device Tree (DTS) to avoid implying flexibility/configurability that is
+ * not yet supported by the underlying code.
+ * Dummy byte count mapping:
+ * - Single SPI: 1 dummy byte  = 8 dummy clock cycles (1 bit per clock)
+ * - QSPI:       4 dummy bytes = 8 dummy clock cycles (4 bits per clock)
+ */
+#define SCQSPI_A1_DUMMY_BYTE_COUNT      1U
+#define SCQSPI_A1_QSPI_DUMMY_BYTE_COUNT 4U
+
+/* Address Lengths */
+#define SCQSPI_A1_ADDR_LEN_3B 3U
+#define SCQSPI_A1_ADDR_LEN_4B 4U
+
+/* FPGA System Controller Configuration Memory Control Register Offsets */
+#define SCOBCA1_REG_CFGMEMCTL_OFFSET 0x0010
+
+/* FPGA System Controller Configuration Memory Control Register Bits */
+#define SCOBCA1_CFGMEMCTL_SEL_VAL(x) (((x) & BIT(0)) << 4)
+#define SCOBCA1_CFGMEMCTL_MON_GET(x) (((x) & BIT(5)) >> 5)
+
+/* FPGA Memory Selection Timing */
+#define SC_FPGA_MEM_SEL_RETRY_CNT 100
+#define SC_FPGA_MEM_SEL_DELAY_US  100
+
+/* Access Control Register (ACR) Masks */
+#define SCQSPI_A1_ACR_SPISSCTL_MASK GENMASK(1, 0)
+
+/* Read Any Register Commands */
+#define SCQSPI_A1_RDAR_CMD 0x65
+/* Write Any Register Commands */
+#define SCQSPI_A1_WRAR_CMD 0x71
+
+/*
+ * ===========================================================================
+ * QSPI Controller Driver - sc,qspi-a1
+ * ===========================================================================
+ */
+#define DT_DRV_COMPAT sc_qspi_a1
+
+typedef void (*irq_config_func_t)(const struct device *dev);
+
+struct sc_qspi_a1_ctrl_config {
+	uint32_t base_address;
+	irq_config_func_t irq_config;
+
+	uint8_t cpol;
+	uint8_t cpha;
+	uint16_t spiclk_div;
+};
+
+struct sc_qspi_a1_ctrl_data {
+	struct k_mutex bus_lock;
+	struct k_sem isr_sem;
+};
+
+static void sc_qspi_a1_ctrl_isr(const struct device *dev)
+{
+	const struct sc_qspi_a1_ctrl_config *cfg = dev->config;
+	struct sc_qspi_a1_ctrl_data *data = dev->data;
+	uint32_t isr;
+
+	isr = sys_read32(cfg->base_address + SCQSPI_A1_ISR_OFFSET);
+	sys_write32(isr, cfg->base_address + SCQSPI_A1_ISR_OFFSET);
+
+	if (isr & SCQSPI_A1_SPICTRLDN) {
+		k_sem_give(&data->isr_sem);
+	}
+}
+
+static void sc_qspi_a1_ctrl_clock_configure(const struct sc_qspi_a1_ctrl_config *cfg)
+{
+	uint32_t clock;
+
+	clock = cfg->cpol << SCQSPI_A1_CCR_SCKPOL_SHIFT | cfg->cpha << SCQSPI_A1_CCR_SCKPHA_SHIFT |
+		cfg->spiclk_div << SCQSPI_A1_CCR_SCKDIV_SHIFT;
+
+	sys_write32(clock, cfg->base_address + SCQSPI_A1_CCR_OFFSET);
+}
+
+static void sc_qspi_a1_ctrl_enable_irq(const struct device *dev)
+{
+	const struct sc_qspi_a1_ctrl_config *cfg = dev->config;
+
+	sys_set_bits(cfg->base_address + SCQSPI_A1_IER_OFFSET, SCQSPI_A1_IER_ALL);
+	cfg->irq_config(dev);
+}
+
+static int sc_qspi_a1_ctrl_init(const struct device *dev)
+{
+	const struct sc_qspi_a1_ctrl_config *cfg = dev->config;
+	struct sc_qspi_a1_ctrl_data *data = dev->data;
+
+	k_mutex_init(&data->bus_lock);
+	k_sem_init(&data->isr_sem, 0, 1);
+
+	sc_qspi_a1_ctrl_clock_configure(cfg);
+
+	sc_qspi_a1_ctrl_enable_irq(dev);
+
+	return 0;
+}
+
+#define SC_QSPI_A1_CTRL_INIT(inst)                                                                 \
+	static void sc_qspi_a1_ctrl_irq_config_##inst(const struct device *dev)                    \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), sc_qspi_a1_ctrl_isr,  \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}                                                                                          \
+                                                                                                   \
+	static const struct sc_qspi_a1_ctrl_config ctrl_cfg_##inst = {                             \
+		.base_address = DT_INST_REG_ADDR(inst),                                            \
+		.irq_config = sc_qspi_a1_ctrl_irq_config_##inst,                                   \
+		.cpol = DT_INST_PROP(inst, cpol),                                                  \
+		.cpha = DT_INST_PROP(inst, cpha),                                                  \
+		.spiclk_div = DT_INST_PROP(inst, spiclk_div),                                      \
+	};                                                                                         \
+                                                                                                   \
+	static struct sc_qspi_a1_ctrl_data ctrl_data_##inst;                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, &sc_qspi_a1_ctrl_init, NULL, &ctrl_data_##inst,                \
+			      &ctrl_cfg_##inst, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,   \
+			      NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(SC_QSPI_A1_CTRL_INIT)
+
+/*
+ * ===========================================================================
+ * QSPI Flash NOR Driver - sc,qspi-nor
+ * ===========================================================================
+ */
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT sc_qspi_nor_a1
+
+/* Build-time data associated with the device. */
+struct sc_qspi_nor_a1_cfg {
+	const struct device *parent;
+
+	/* Size of device in bytes, from size property */
+	uint32_t flash_size;
+
+	/* Memory selected number */
+	uint8_t mem_no;
+
+	/* Expected JEDEC ID, from jedec-id property */
+	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
+
+	/* Base address of FPGA system controller, if used */
+	uint32_t sysreg_base_addr;
+};
+
+struct sc_qspi_nor_a1_data {
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	struct flash_pages_layout layout;
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+};
+
+static const struct flash_parameters flash_nor_parameters = {
+	.write_block_size = 1,
+	.erase_value = 0xff,
+};
+
+static int sc_qspi_nor_a1_select_cfg_mem(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	uint32_t reg_addr = cfg->sysreg_base_addr + SCOBCA1_REG_CFGMEMCTL_OFFSET;
+	uint32_t reg_val;
+	int retry = SC_FPGA_MEM_SEL_RETRY_CNT;
+
+	sys_write32(SCOBCA1_CFGMEMCTL_SEL_VAL(cfg->mem_no), reg_addr);
+
+	/* Check we actually change the selected memory */
+	while (retry--) {
+		reg_val = sys_read32(reg_addr);
+		if (SCOBCA1_CFGMEMCTL_MON_GET(reg_val) == cfg->mem_no) {
+			return 0;
+		}
+		k_busy_wait(SC_FPGA_MEM_SEL_DELAY_US);
+	}
+
+	LOG_ERR("Failed to select Config Memory %d via fpga system register", cfg->mem_no);
+	return -ETIMEDOUT;
+}
+
+static void acquire_device(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	struct sc_qspi_a1_ctrl_data *parent_data = cfg->parent->data;
+
+	k_mutex_lock(&parent_data->bus_lock, K_FOREVER);
+}
+
+static void release_device(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	struct sc_qspi_a1_ctrl_data *parent_data = cfg->parent->data;
+
+	k_mutex_unlock(&parent_data->bus_lock);
+}
+
+static uint32_t get_base_addr(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	const struct sc_qspi_a1_ctrl_config *parent_cfg = cfg->parent->config;
+
+	return parent_cfg->base_address;
+}
+
+static int sc_qspi_a1_wait_for_idle(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	struct sc_qspi_a1_ctrl_data *parent_data = cfg->parent->data;
+	int ret;
+
+	/* Waiting for the 'SPICTRLDN' interrupt from the FPGA. */
+	ret = k_sem_take(&parent_data->isr_sem, K_MSEC(CONFIG_SC_QSPI_NOR_A1_IDLE_TIMEOUT_MS));
+	if (ret < 0) {
+		LOG_ERR("Timeout waiting for idle interrupt (%d)", ret);
+	}
+
+	return ret;
+}
+
+static int sc_qspi_a1_cs_control(const struct device *dev, bool quad_mode)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	const uint32_t acr_reg_addr = get_base_addr(dev) + SCQSPI_A1_ACR_OFFSET;
+	uint32_t target_acr;
+	uint32_t current_acr;
+
+	if (cfg->sysreg_base_addr != 0) {
+		int ret = sc_qspi_nor_a1_select_cfg_mem(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		/* With the flash configuration memory we always use SCQSPI_A1_ACR_SS1 because we
+		 * change selected memory from the fpga system register */
+		target_acr = SCQSPI_A1_ACR_SS1;
+	} else {
+		target_acr = BIT(cfg->mem_no);
+	}
+
+	current_acr = sys_read32(acr_reg_addr);
+
+	if (quad_mode) {
+		target_acr |= SCQSPI_A1_ACR_MODE_QUAD;
+	}
+	sys_write32(target_acr, acr_reg_addr);
+
+	/* Check if Chip Select control bits have changed, if the CS signal hasn't physically
+	 * changed, we don't need to wait for idl. */
+	if ((current_acr & SCQSPI_A1_ACR_SPISSCTL_MASK) ==
+	    (target_acr & SCQSPI_A1_ACR_SPISSCTL_MASK)) {
+		return 0;
+	}
+
+	/* The CS has changed (e.g. from Negated to Asserted), so we must wait for the controller to
+	 * become idle. */
+	return sc_qspi_a1_wait_for_idle(dev);
+}
+
+static int sc_qspi_a1_cs_activate(const struct device *dev)
+{
+	return sc_qspi_a1_cs_control(dev, false);
+}
+
+static int sc_qspi_a1_cs_activate_quad(const struct device *dev)
+{
+	return sc_qspi_a1_cs_control(dev, true);
+}
+
+static int sc_qspi_a1_cs_inactivate(const struct device *dev)
+{
+	sys_write32(SCQSPI_A1_ACR_SS_OFF, get_base_addr(dev) + SCQSPI_A1_ACR_OFFSET);
+
+	return sc_qspi_a1_wait_for_idle(dev);
+}
+
+static int sc_qspi_nor_a1_write_mem_addr(const struct device *dev, uint32_t mem_addr, uint8_t len)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+	uint8_t byte;
+
+	for (int i = len - 1; i >= 0; --i) {
+		byte = (mem_addr >> (i * 8)) & 0xFF;
+		sys_write32(byte, addr_tdr);
+
+		ret = sc_qspi_a1_wait_for_idle(dev);
+		if (ret < 0) {
+			LOG_ERR("Failed to write addr byte %d (0x%08x)", i, mem_addr);
+			return ret;
+		}
+	}
+
+	return ret;
+}
+
+static int sc_qspi_nor_a1_send_cmd(const struct device *dev, uint8_t cmd)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+	int ret_inact;
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write32(cmd, addr_tdr);
+
+	ret = sc_qspi_a1_wait_for_idle(dev);
+
+	ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_write_disable(const struct device *dev)
+{
+	return sc_qspi_nor_a1_send_cmd(dev, SPI_NOR_CMD_WRDI);
+}
+
+static int sc_qspi_nor_a1_write_enable(const struct device *dev)
+{
+	return sc_qspi_nor_a1_send_cmd(dev, SPI_NOR_CMD_WREN);
+}
+
+static int sc_qspi_nor_a1_request_rx_data(const struct device *dev, size_t size)
+{
+	const uint32_t base = get_base_addr(dev);
+	const uint32_t addr_rdr = base + SCQSPI_A1_RDR_OFFSET;
+
+	for (int i = 0; i < size; i++) {
+		sys_write32(0x00, addr_rdr);
+	}
+
+	return sc_qspi_a1_wait_for_idle(dev);
+}
+
+/*
+ * Read RX data from QSPI NOR flash into buffer.
+ * If 'buf' is NULL, data is read and discarded. (Dummy Cycle)
+ */
+static int sc_qspi_nor_a1_read_rx_data(const struct device *dev, uint8_t *buf, size_t size)
+{
+	const uint32_t base = get_base_addr(dev);
+	const uint32_t addr_rdr = base + SCQSPI_A1_RDR_OFFSET;
+	int ret = 0;
+	size_t bytes = 0;
+
+	while (bytes < size) {
+		size_t chunk = MIN(SCQSPI_A1_RX_FIFO_MAX_BYTE, size - bytes);
+
+		ret = sc_qspi_nor_a1_request_rx_data(dev, chunk);
+		if (ret < 0) {
+			LOG_ERR("Timeout while requesting RX data (%d)", ret);
+			return ret;
+		}
+
+		for (size_t i = 0; i < chunk; i++) {
+			if (buf) {
+				uint32_t reg_val = sys_read32(addr_rdr);
+				buf[bytes + i] = (uint8_t)reg_val;
+			} else {
+				(void)sys_read32(addr_rdr);
+			}
+		}
+
+		bytes += chunk;
+	}
+
+	return ret;
+}
+
+static int sc_qspi_nor_a1_send_dummy_cycle(const struct device *dev, uint8_t count)
+{
+	int ret;
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, NULL, count);
+	if (ret < 0) {
+		LOG_ERR("Timeout while sending dummy cycles (%d)", ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int sc_qspi_nor_a1_read_status(const struct device *dev, uint8_t *status_reg)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+
+	if (!status_reg) {
+		return -EINVAL;
+	}
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write32(SPI_NOR_CMD_RDSR, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, status_reg, 1);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_wait_ready(const struct device *dev, uint32_t poll_delay_us,
+				     uint32_t timeout_us)
+{
+	uint8_t status_reg;
+	int ret;
+	uint32_t max_loops = timeout_us / poll_delay_us;
+
+	/*
+	 * The 'max_loops' calculation differs significantly between operations:
+	 * - Page Program (Write): Very fast (~300us typical (S25FL256L)). Short sleep, few loops.
+	 * - Block Erase: Slow (~50ms to 725ms typical (S25FL256L)). Longer sleep to save CPU, many
+	 * loops.
+	 */
+	for (uint32_t i = 0; i < max_loops; i++) {
+		k_usleep(poll_delay_us);
+		status_reg = 0;
+		ret = sc_qspi_nor_a1_read_status(dev, &status_reg);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (!(status_reg & SPI_NOR_WIP_BIT) && !(status_reg & SPI_NOR_WEL_BIT)) {
+			return 0;
+		}
+	}
+
+	/* Timeout diagnostics */
+	if (status_reg & SPI_NOR_WIP_BIT) {
+		LOG_ERR("Timeout waiting for Write In Progress (WIP) to clear (SR=0x%02x)",
+			(uint8_t)status_reg);
+	}
+
+	if (status_reg & SPI_NOR_WEL_BIT) {
+		LOG_ERR("Timeout waiting for Write Enable Latch (WEL) to clear (SR=0x%02x)",
+			(uint8_t)status_reg);
+		/* Try to recover by explicitly clearing WEL */
+		(void)sc_qspi_nor_a1_write_disable(dev);
+	}
+
+	return -ETIMEDOUT;
+}
+
+/*
+ * Write to any internal register using WRAR (0x71).
+ * Requires WREN before sending the command.
+ */
+int sc_qspi_nor_a1_write_any_reg(const struct device *dev, uint32_t reg_addr, uint8_t val)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+	uint32_t timeout = CONFIG_SC_QSPI_NOR_A1_WRITE_TIMEOUT_US;
+	uint32_t poll_delay = CONFIG_SC_QSPI_NOR_A1_SLEEP_WRITE_US;
+
+	/*
+	 * Si l'adresse est < 0x800000, c'est un registre Non-Volatile (NV).
+	 * L'écriture prend beaucoup plus de temps (similaire à un Erase ou Write long).
+	 * On utilise le timeout d'Erase pour être sûr (~100ms+).
+	 */
+	if (reg_addr < 0x800000) {
+		/* MS to US */
+		timeout = CONFIG_SC_QSPI_NOR_A1_ERASE_TIMEOUT_MS * 1000U;
+		poll_delay = CONFIG_SC_QSPI_NOR_A1_SLEEP_ERASE_MS * 1000U;
+	}
+
+	acquire_device(dev);
+
+	ret = sc_qspi_nor_a1_write_enable(dev);
+	if (ret < 0) {
+		release_device(dev);
+		return ret;
+	}
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		release_device(dev);
+		return ret;
+	}
+
+	sys_write32(SCQSPI_A1_WRAR_CMD, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, reg_addr, SCQSPI_A1_ADDR_LEN_3B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	sys_write32(val, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (ret_inact < 0) {
+		return ret_inact;
+	}
+
+	ret = sc_qspi_nor_a1_wait_ready(dev, CONFIG_SC_QSPI_NOR_A1_SLEEP_WRITE_US,
+					CONFIG_SC_QSPI_NOR_A1_WRITE_TIMEOUT_US);
+
+	release_device(dev);
+
+	return (ret < 0) ? ret : ret_inact;
+}
+
+int sc_qspi_nor_a1_read_any_reg(const struct device *dev, uint32_t reg_addr, uint8_t *val)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+
+	if (!val) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		release_device(dev);
+		return ret;
+	}
+
+	sys_write32(SCQSPI_A1_RDAR_CMD, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, reg_addr, SCQSPI_A1_ADDR_LEN_3B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_send_dummy_cycle(dev, SCQSPI_A1_DUMMY_BYTE_COUNT);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, val, 1);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+	release_device(dev);
+
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_quad_read_internal(const struct device *dev, off_t addr, uint8_t *buf,
+					     size_t size)
+{
+	uint32_t mem_addr = (uint32_t)addr;
+	const uint32_t base = get_base_addr(dev);
+	const uint32_t addr_tdr = base + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write32(SPI_NOR_CMD_4READ_4B, addr_tdr);
+
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to send 4READ_4B opcode (%d)", ret);
+		goto out_cs;
+	}
+
+	ret = sc_qspi_a1_cs_activate_quad(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, mem_addr, SCQSPI_A1_ADDR_LEN_4B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	sys_write32(0x00, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to send mode byte (%d)", ret);
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_send_dummy_cycle(dev, SCQSPI_A1_QSPI_DUMMY_BYTE_COUNT);
+	if (ret < 0) {
+		LOG_ERR("Failed to send dummy cycles (%d)", ret);
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, buf, size);
+	if (ret < 0) {
+		LOG_ERR("Failed to read RX data (%d)", ret);
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_read(const struct device *dev, off_t addr, void *dest, size_t size)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	int ret;
+
+	if (!dest) {
+		return -EINVAL;
+	}
+
+	if (addr < 0 || (addr + size) > cfg->flash_size) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+	ret = sc_qspi_nor_a1_quad_read_internal(dev, addr, (uint8_t *)dest, size);
+	release_device(dev);
+
+	return ret;
+}
+
+static int sc_qspi_nor_a1_page_program_internal(const struct device *dev, uint32_t addr,
+						const uint8_t *src, size_t len)
+{
+	const uint32_t addr_tdr = get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+
+	if (!src || len == 0 || len > SCQSPI_A1_PAGE_BUFFER_BYTE) {
+		return -EINVAL;
+	}
+
+	ret = sc_qspi_nor_a1_write_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write32(SPI_NOR_CMD_PP_4B, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, addr, SCQSPI_A1_ADDR_LEN_4B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		sys_write32(src[i], addr_tdr);
+	}
+
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (ret_inact < 0) {
+		return ret_inact;
+	}
+
+	return sc_qspi_nor_a1_wait_ready(dev, CONFIG_SC_QSPI_NOR_A1_SLEEP_WRITE_US,
+					 CONFIG_SC_QSPI_NOR_A1_WRITE_TIMEOUT_US);
+}
+
+static int sc_qspi_nor_a1_write(const struct device *dev, off_t addr, const void *src, size_t size)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	const uint8_t *src_ptr = src;
+	uint32_t curr_addr = (uint32_t)addr;
+	int ret = 0;
+
+	if (!src) {
+		return -EINVAL;
+	}
+
+	if ((addr < 0) || ((addr + size) > cfg->flash_size)) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+
+	while (size > 0) {
+		size_t page_off = curr_addr % SCQSPI_A1_PAGE_BUFFER_BYTE;
+		size_t space_in_page = SCQSPI_A1_PAGE_BUFFER_BYTE - page_off;
+		size_t chunk = (size < space_in_page) ? size : space_in_page;
+
+		ret = sc_qspi_nor_a1_page_program_internal(dev, curr_addr, src_ptr, chunk);
+		if (ret < 0) {
+			break;
+		}
+
+		curr_addr += chunk;
+		src_ptr += chunk;
+		size -= chunk;
+	}
+
+	release_device(dev);
+	return ret;
+}
+
+static int sc_qspi_nor_a1_block_erase_internal(const struct device *dev, uint8_t cmd, uint32_t addr)
+{
+	int ret;
+
+	ret = sc_qspi_nor_a1_write_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write32(cmd, get_base_addr(dev) + SCQSPI_A1_TDR_OFFSET);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, addr, SCQSPI_A1_ADDR_LEN_4B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (ret_inact < 0) {
+		return ret_inact;
+	}
+
+	return sc_qspi_nor_a1_wait_ready(dev, (CONFIG_SC_QSPI_NOR_A1_SLEEP_ERASE_MS * 1000U),
+					 (CONFIG_SC_QSPI_NOR_A1_ERASE_TIMEOUT_MS * 1000U));
+}
+
+static int sc_qspi_nor_a1_erase(const struct device *dev, off_t addr, size_t size)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	uint32_t curr_addr = (uint32_t)addr;
+	int ret = 0;
+
+	if ((addr < 0) || ((addr + size) > cfg->flash_size)) {
+		return -EINVAL;
+	}
+
+	if (!SPI_NOR_IS_SECTOR_ALIGNED(curr_addr) || !SPI_NOR_IS_SECTOR_ALIGNED(size)) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+
+	while (size > 0) {
+		uint8_t cmd;
+		size_t chunk;
+
+		/* Smart Erase: Prefer 64KB Block Erase if aligned and big enough */
+		if ((curr_addr % SPI_NOR_BLOCK_SIZE == 0) && (size >= SPI_NOR_BLOCK_SIZE)) {
+			cmd = SPI_NOR_CMD_BE_4B;
+			chunk = SPI_NOR_BLOCK_SIZE;
+			LOG_DBG("Block Erase (64KB) @ 0x%08x", curr_addr);
+		} else {
+			cmd = SPI_NOR_CMD_SE_4B;
+			chunk = SPI_NOR_SECTOR_SIZE;
+			LOG_DBG("Sector Erase (4KB) @ 0x%08x", curr_addr);
+		}
+
+		ret = sc_qspi_nor_a1_block_erase_internal(dev, cmd, curr_addr);
+		if (ret < 0) {
+			break;
+		}
+
+		curr_addr += chunk;
+		size -= chunk;
+	}
+
+	release_device(dev);
+	return ret;
+}
+
+/*
+ * Read Serial Flash Discovery Parameter
+ */
+static int sc_qspi_nor_a1_read_sfdp(const struct device *dev, off_t addr, void *data, size_t size)
+{
+	const uint32_t base = get_base_addr(dev);
+	const uint32_t addr_tdr = base + SCQSPI_A1_TDR_OFFSET;
+	uint8_t *buf = (uint8_t *)data;
+	int ret;
+
+	if (!data) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		release_device(dev);
+		return ret;
+	}
+
+	sys_write32(JESD216_CMD_READ_SFDP, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_write_mem_addr(dev, addr, SCQSPI_A1_ADDR_LEN_3B);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_send_dummy_cycle(dev, SCQSPI_A1_DUMMY_BYTE_COUNT);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, buf, size);
+	if (ret < 0) {
+		LOG_ERR("Failed to read RX data (%d)", ret);
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	release_device(dev);
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_read_jedec_id(const struct device *dev, uint8_t *id_buf)
+{
+	const uint32_t base = get_base_addr(dev);
+	const uint32_t addr_tdr = base + SCQSPI_A1_TDR_OFFSET;
+	int ret;
+
+	if (!id_buf) {
+		return -EINVAL;
+	}
+
+	acquire_device(dev);
+	ret = sc_qspi_a1_cs_activate(dev);
+	if (ret < 0) {
+		release_device(dev);
+		return ret;
+	}
+
+	sys_write32(SPI_NOR_CMD_RDID, addr_tdr);
+	ret = sc_qspi_a1_wait_for_idle(dev);
+	if (ret < 0) {
+		goto out_cs;
+	}
+
+	ret = sc_qspi_nor_a1_read_rx_data(dev, id_buf, SPI_NOR_MAX_ID_LEN);
+	if (ret < 0) {
+		LOG_ERR("Failed to read RX data (%d)", ret);
+		goto out_cs;
+	}
+
+out_cs:
+	int ret_inact = sc_qspi_a1_cs_inactivate(dev);
+
+	release_device(dev);
+	return (ret < 0) ? ret : ret_inact;
+}
+
+static int sc_qspi_nor_a1_init(const struct device *dev)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+	struct sc_qspi_nor_a1_data *data = dev->data;
+	int ret;
+
+	/* Check JEDEC ID  */
+	uint8_t jedec_id_read[SPI_NOR_MAX_ID_LEN];
+
+	ret = sc_qspi_nor_a1_read_jedec_id(dev, jedec_id_read);
+	if (ret < 0) {
+		LOG_ERR("Failed to read JEDEC ID (%d)", ret);
+		return ret;
+	}
+
+	if (memcmp(jedec_id_read, cfg->jedec_id, SPI_NOR_MAX_ID_LEN) != 0) {
+		LOG_ERR("JEDEC ID mismatch: read %02x %02x %02x, expected %02x %02x %02x",
+			jedec_id_read[0], jedec_id_read[1], jedec_id_read[2], cfg->jedec_id[0],
+			cfg->jedec_id[1], cfg->jedec_id[2]);
+		return -ENODEV;
+	}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	data->layout.pages_count = cfg->flash_size / SPI_NOR_SECTOR_SIZE;
+	data->layout.pages_size = SPI_NOR_SECTOR_SIZE;
+#endif
+
+	return ret;
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+
+static void sc_qspi_nor_a1_pages_layout(const struct device *dev,
+					const struct flash_pages_layout **layout,
+					size_t *layout_size)
+{
+	const struct sc_qspi_nor_a1_data *data = dev->data;
+
+	*layout = &data->layout;
+
+	*layout_size = 1;
+}
+
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+static const struct flash_parameters *sc_qspi_nor_a1_get_parameters(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return &flash_nor_parameters;
+}
+
+static int sc_qspi_nor_a1_get_size(const struct device *dev, uint64_t *size)
+{
+	const struct sc_qspi_nor_a1_cfg *cfg = dev->config;
+
+	*size = (uint64_t)cfg->flash_size;
+
+	return 0;
+}
+
+static DEVICE_API(flash, sc_qspi_nor_a1_api) = {
+	.read = sc_qspi_nor_a1_read,
+	.write = sc_qspi_nor_a1_write,
+	.erase = sc_qspi_nor_a1_erase,
+	.get_parameters = sc_qspi_nor_a1_get_parameters,
+	.get_size = sc_qspi_nor_a1_get_size,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = sc_qspi_nor_a1_pages_layout,
+#endif
+#if defined(CONFIG_FLASH_JESD216_API)
+	.sfdp_read = sc_qspi_nor_a1_read_sfdp,
+	.read_jedec_id = sc_qspi_nor_a1_read_jedec_id,
+#endif /* CONFIG_FLASH_JESD216_API */
+};
+
+#define SC_QSPI_NOR_A1_INST(inst)                                                                  \
+	static const struct sc_qspi_nor_a1_cfg sc_qspi_nor_a1_cfg_##inst = {                       \
+		.mem_no = DT_INST_PROP(inst, mem_no),                                              \
+		.flash_size = DT_INST_PROP(inst, size),                                            \
+		.jedec_id = DT_INST_PROP(inst, jedec_id),                                          \
+		.parent = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                     \
+		.sysreg_base_addr = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, sc_sysreg),         \
+                                  (DT_REG_ADDR(DT_INST_PHANDLE(inst, sc_sysreg))), \
+                                  (0)),                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct sc_qspi_nor_a1_data sc_qspi_nor_a1_data_##inst;                              \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, sc_qspi_nor_a1_init, NULL, &sc_qspi_nor_a1_data_##inst,        \
+			      &sc_qspi_nor_a1_cfg_##inst, POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY, \
+			      &sc_qspi_nor_a1_api);
+
+DT_INST_FOREACH_STATUS_OKAY(SC_QSPI_NOR_A1_INST)

--- a/drivers/flash/flash_sc_qspi_a1.h
+++ b/drivers/flash/flash_sc_qspi_a1.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FLASH_SC_QSPI_A1_H_
+#define ZEPHYR_DRIVERS_FLASH_SC_QSPI_A1_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Read any register from the SC QSPI NOR Flash of the SC-OBC Module A1 using RDAR (0x65)
+ * command.
+ *
+ * This function allows reading Volatile and Non-Volatile registers directly
+ * by their memory address (Refer to the Datasheet).
+ *
+ * @param dev      Pointer to the device structure.
+ * @param reg_addr The register address (e.g., 0x800000 for SR1V for S25FL256L).
+ * @param val      Pointer to a 8-bit variable to store the read value.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int sc_qspi_nor_a1_read_any_reg(const struct device *dev, uint32_t reg_addr, uint8_t *val);
+
+/**
+ * @brief Write to any register in the SC QSPI NOR Flash of the SC-OBC Module A1 using WRAR (0x71)
+ * command.
+ *
+ * This function allows writing to Volatile and Non-Volatile registers directly
+ * by their memory address (Refer to the Datasheet).
+ *
+ * @param dev      Pointer to the device structure.
+ * @param reg_addr The register address (e.g., 0x800000 for SR1V for S25FL256L).
+ * @param val      The 8-bit value to write to the register.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int sc_qspi_nor_a1_write_any_reg(const struct device *dev, uint32_t reg_addr, uint8_t val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_FLASH_SC_QSPI_A1_H_ */

--- a/samples/flash/CMakeLists.txt
+++ b/samples/flash/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(flash-sample)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/flash/prj.conf
+++ b/samples/flash/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_FLASH=y

--- a/samples/flash/src/main.c
+++ b/samples/flash/src/main.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025 Space Cubics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+
+#include "../../../drivers/flash/flash_sc_qspi_a1.h"
+
+/*
+ * Register Addresses Map (S25FL256L / S25FL128L)
+ * Based on Table 42 of the Datasheet.
+ */
+
+/* --- Non-Volatile Registers (Stored in Flash memory) --- */
+#define ADDR_CR1NV 0x000002 /* Configuration Register 1 NV */
+#define ADDR_CR2NV 0x000003 /* Configuration Register 2 NV */
+#define ADDR_CR3NV 0x000004 /* Configuration Register 3 NV */
+
+/* --- Volatile Registers (Shadow registers in RAM, active settings) --- */
+#define ADDR_SR1V 0x800000 /* Status Register 1 Volatile */
+#define ADDR_SR2V 0x800001 /* Status Register 2 Volatile */
+#define ADDR_CR1V 0x800002 /* Configuration Register 1 Volatile */
+#define ADDR_CR2V 0x800003 /* Configuration Register 2 Volatile */
+#define ADDR_CR3V 0x800004 /* Configuration Register 3 Volatile */
+
+/* Target: data_flash0 as defined in the Device Tree */
+#define FLASH_DEVICE_NODE DT_NODELABEL(data_flash0)
+
+#define TEST_CHUNK_SIZE 256
+#define SECTOR_SIZE     4096
+#define TEST_OFFSET     0x00000000 /* Test at the beginning of flash */
+
+static uint8_t wr_buf[TEST_CHUNK_SIZE];
+static uint8_t rd_buf[TEST_CHUNK_SIZE];
+
+/* Helper function to read and log a register */
+static void read_and_log_reg(const struct device *dev, const char *reg_name, uint32_t addr)
+{
+	uint8_t val;
+	int ret;
+
+	ret = sc_qspi_nor_a1_read_any_reg(dev, addr, &val);
+
+	if (ret == 0) {
+		printf("%-6s (Addr: 0x%06x) = 0x%02x\n", reg_name, addr, val);
+	} else {
+		printf("Failed to read %s (Addr: 0x%06x), Error: %d\n", reg_name, addr, ret);
+	}
+}
+
+static int verify_erased(const uint8_t *buf, size_t len)
+{
+	for (size_t i = 0; i < len; i++) {
+		if (buf[i] != 0xFF) {
+			printf("Erase verification failed, aborting at offset %zu: 0x%02x\n", i,
+				buf[i]);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int verify_data(const uint8_t *expected, const uint8_t *read, size_t len)
+{
+	for (size_t i = 0; i < len; i++) {
+		if (expected[i] != read[i]) {
+			printf("Data mismatch, aborting at offset %zu: expected 0x%02x, got "
+				"0x%02x\n",
+				i, expected[i], read[i]);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+int main(void)
+{
+	const struct device *flash_dev = DEVICE_DT_GET(FLASH_DEVICE_NODE);
+	int ret;
+
+	printf("=== TEST DATA_FLASH0 ===\n");
+
+	if (!device_is_ready(flash_dev)) {
+		printf("Error: Device data_flash0 is not ready or not found!\n");
+		return -1;
+	}
+
+	printf("Device found: %s\n", flash_dev->name);
+
+	printf("1. Erasing sector at 0x%x...\n", TEST_OFFSET);
+	ret = flash_erase(flash_dev, TEST_OFFSET, SECTOR_SIZE);
+	if (ret != 0) {
+		printf("Erase failed: %d\n", ret);
+		return -1;
+	}
+
+	printf("2. Erased sector verification at 0x%x...\n", TEST_OFFSET);
+	memset(rd_buf, 0, TEST_CHUNK_SIZE);
+	ret = flash_read(flash_dev, TEST_OFFSET, rd_buf, TEST_CHUNK_SIZE);
+	if (ret != 0) {
+		printf("Read after erase failed: %d\n", ret);
+		return -1;
+	}
+
+	ret = verify_erased(rd_buf, sizeof(rd_buf));
+	if (ret) {
+		printf("Erase verification FAILED\n");
+		return -1;
+	}
+
+	printf("Erase verification OK\n");
+
+	for (size_t i = 0; i < TEST_CHUNK_SIZE; i++) {
+		wr_buf[i] = (uint8_t)(i + 0x55); /* Simple incrementing pattern */
+	}
+
+	printf("3. Writing %d bytes...\n", TEST_CHUNK_SIZE);
+	ret = flash_write(flash_dev, TEST_OFFSET, wr_buf, TEST_CHUNK_SIZE);
+	if (ret != 0) {
+		printf("Write failed: %d\n", ret);
+		return -1;
+	}
+
+	printf("4. Wrote data readback and verification at 0x%x...\n", TEST_OFFSET);
+	memset(rd_buf, 0, TEST_CHUNK_SIZE);
+	ret = flash_read(flash_dev, TEST_OFFSET, rd_buf, TEST_CHUNK_SIZE);
+	if (ret != 0) {
+		printf("Read failed: %d\n", ret);
+		return -1;
+	}
+
+	ret = verify_data(wr_buf, rd_buf, TEST_CHUNK_SIZE);
+	if (ret) {
+		printf("Write/Read verification FAILED\n");
+		return -1;
+	}
+
+	printf("Write verification OK\n");
+
+	printf("==========================================\n");
+	printf("   S25FL256L Register Dump (RDAR 0x65)    \n");
+	printf("==========================================\n");
+
+	/* 1. Read Non-Volatile Registers (Factory/Stored Settings) */
+	printf("--- Non-Volatile Registers (NV) ---\n");
+	read_and_log_reg(flash_dev, "CR1NV", ADDR_CR1NV);
+	read_and_log_reg(flash_dev, "CR2NV", ADDR_CR2NV);
+	read_and_log_reg(flash_dev, "CR3NV", ADDR_CR3NV);
+
+	/* 2. Read Volatile Registers (Current Active Settings) */
+	printf("--- Volatile Registers (V) ---\n");
+	read_and_log_reg(flash_dev, "SR1V", ADDR_SR1V);
+	read_and_log_reg(flash_dev, "SR2V", ADDR_SR2V);
+	read_and_log_reg(flash_dev, "CR1V", ADDR_CR1V);
+	read_and_log_reg(flash_dev, "CR2V", ADDR_CR2V);
+	read_and_log_reg(flash_dev, "CR3V", ADDR_CR3V);
+
+	return 0;
+}

--- a/zephyr/dts/bindings/flash_controller/sc,qspi-nor-a1.yaml
+++ b/zephyr/dts/bindings/flash_controller/sc,qspi-nor-a1.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Space Cubics SC-OBC Module A1 QSPI NOR Flash Controller
+
+    Representation of a serial flash on a quadspi bus:
+
+        qspi: qspi@40100000 {
+            compatible = "sc,qspi-a1";
+            reg = <0x40100000 0x1000>;
+            interrupts = <3 0>;
+            cpol = <0>;
+            cpha = <0>;
+            spiclk-div = <0>;
+            status = "okay";
+
+            data_flash0: flash0 {
+                compatible = "sc,qspi-nor-a1";
+                mem-no = <0>;
+                size = <DT_SIZE_M(32)>;
+                jedec-id = [01 60 19];
+                status = "okay";
+            };
+        };
+
+compatible: "sc,qspi-nor-a1"
+
+include: ["jedec,jesd216.yaml"]
+
+on-bus: qspi
+
+properties:
+  mem-no:
+    type: int
+    description: NOR Flash memory number (0 or 1).
+    required: true
+
+  size:
+    description: Flash Memory size in octets
+    required: true
+
+  jedec-id:
+    type: uint8-array
+    description: 3-byte JEDEC ID of the NOR flash
+    required: true
+
+  sc-sysreg:
+    type: phandle
+    description: |
+      Reference to the system register node (sysreg).
+      Required if configuration memory, it's used to handle memory selection.

--- a/zephyr/dts/bindings/qspi/sc,qspi-a1.yaml
+++ b/zephyr/dts/bindings/qspi/sc,qspi-a1.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Space Cubics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Space Cubics SC-OBC Module A1 QSPI Controller
+
+compatible: "sc,qspi-a1"
+
+include: base.yaml
+
+properties:
+  reg:
+    description: QSPI controller register base address and size
+    required: true
+
+  interrupts:
+    description: QSPI interrupt specifier (IRQ, priority)
+    required: true
+
+  cpol:
+    type: int
+    description: Clock Polarity in SPI
+    required: true
+
+  cpha:
+    type: int
+    description: Clock Phase in SPI
+    required: true
+
+  spiclk-div:
+    type: int
+    description: Clock divider for the SPI clock relative to the system clock
+    required: true
+
+bus: qspi


### PR DESCRIPTION
This PR introduces the driver for the **Space Cubics QSPI NOR Flash controller** (`sc,qspi-nor`) for the SC-OBC Module A1.
It includes the necessary Device Tree bindings, the driver implementation, and a sample application.

#### Overview of changes
1.  **Device Tree & Bindings:**
    *   Added YAML bindings for `sc,qspi` (controller) and `sc,qspi-nor` (flash).
    *   Added QSPI definitions to the board overlay, including `fpgasys` integration for configuration memory selection.
    *   Defined `qspi_cfg` (Configuration Flash) and `qspi_data` (Data Flash) nodes with partitions.
2.  **Flash Driver (`drivers/flash/sc_qspi_nor.c`):**
    *   **Initialization:** JEDEC ID verification.
    *   **Read:** Supports Quad Output Fast Read (`4READ_4B`).
    *   **Write:** Implements Page Programming.
    *   **Erase:** Supports both Sector Erase (4KB) and Block Erase (64KB).
    *   **Config Memory:** Manages memory selection via the FPGA System Controller (`fpgasys`).
3.  **Sample Application (`samples/flash/src/main.c`):**
    *   A test application targeting `data_flash1`.
    *   Validates the full cycle: Erase -> Verify Empty -> Write Pattern -> Read & Compare.
 
 > [!note]
> As of this writing, Zephyr does NOT have a clean QSPI controller driver framework. Thus, this driver implementation follows the other current implementations and has both the flash memory (S25FL256) and QSPI controller (SC-QSPI) driver. Please refer to https://github.com/zephyrproject-rtos/zephyr/issues/46399 for more details about Zephyr SPI frame work.
Here the diagram from **https://github.com/zephyrproject-rtos/zephyr/issues/46399**
<img width="1125" height="524" alt="image" src="https://github.com/user-attachments/assets/a0b69e2a-533d-468e-a69b-8466c561b677" />


#### Testing
Tested with the sample, and zephyr test.
To run the zephyr test it needs some modifications in the zephyr repository. (Here I will not pasted every modification it needed, I will create a clean notion page to explain it.

https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/drivers/flash/common
`west build -b scobc_a1 --shield scobc_a1_dev -p always ../zephyr/tests/drivers/flash/common/ -- -DCONFIG_TEST_DRIVER_FLASH_SIZE=33554432`

```
SUITE PASS - 100.00% [flash_driver]: pass = 7, fail = 0, skip = 0, total = 7 duration = 1.120 seconds
 - PASS - [flash_driver.test_flash_copy] duration = 0.360 seconds
 - PASS - [flash_driver.test_flash_erase] duration = 0.105 seconds
 - PASS - [flash_driver.test_flash_fill] duration = 0.166 seconds
 - PASS - [flash_driver.test_flash_flatten] duration = 0.201 seconds
 - PASS - [flash_driver.test_flash_page_layout] duration = 0.072 seconds
 - PASS - [flash_driver.test_get_size] duration = 0.010 seconds
 - PASS - [flash_driver.test_read_unaligned_address] duration = 0.206 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/drivers/flash/erase_blocks
`west build -b scobc_a1 --shield scobc_a1_dev -p always ../zephyr/tests/drivers/flash/erase_blocks/`

```
===================================================================
TESTSUITE flash_page_layout succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [flash_page_layout]: pass = 2, fail = 0, skip = 0, total = 2 duration = 52.691 seconds
 - PASS - [flash_page_layout.test_erase_single_pages_in_part] duration = 31.341 seconds
 - PASS - [flash_page_layout.test_write_across_page_boundaries_in_part] duration = 21.350 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/drivers/flash/negative_tests
`west build -b scobc_a1 --shield scobc_a1_dev     ../zephyr/tests/drivers/flash/negative_tests/`

```
SUITE FAIL -  80.00% [flash_driver_negative]: pass = 4, fail = 1, skip = 0, total = 5 duration = 0.149 seconds
 - PASS - [flash_driver_negative.test_negative_flash_erase] duration = 0.001 seconds
 - FAIL - [flash_driver_negative.test_negative_flash_fill] duration = 0.145 seconds
 - PASS - [flash_driver_negative.test_negative_flash_flatten] duration = 0.001 seconds
 - PASS - [flash_driver_negative.test_negative_flash_read] duration = 0.001 seconds
 - PASS - [flash_driver_negative.test_negative_flash_write] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION FAILED
```

Negative test fail on the test_negative_flash_fill function.
The Zephyr flash driver negative tests expects the write function to reject unaligned writes based on write_block_size. Our current implementation allows byte-level writes (write_block_size = 1), causing the alignment check to always pass.

https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/subsys/fs/littlefs
`west build -p always -b scobc_a1 --shield scobc_a1_dev -p always ../zephyr/tests/subsys/fs/littlefs/`

```
SUITE PASS - 100.00% [littlefs]: pass = 14, fail = 0, skip = 0, total = 14 duration = 12.339 seconds
 - PASS - [littlefs.test_fs_mkfs_custom] duration = 0.339 seconds
 - PASS - [littlefs.test_fs_mkfs_ops_lfs] duration = 0.571 seconds
 - PASS - [littlefs.test_fs_mkfs_simple_lfs] duration = 0.373 seconds
 - PASS - [littlefs.test_fs_mount_flags_lfs] duration = 0.503 seconds
 - PASS - [littlefs.test_fs_open_flags_lfs] duration = 3.214 seconds
 - PASS - [littlefs.test_lfs_basic] duration = 1.780 seconds
 - PASS - [littlefs.test_lfs_dirops] duration = 4.509 seconds
 - PASS - [littlefs.test_lfs_perf] duration = 1.044 seconds
 - PASS - [littlefs.test_util_path_extend] duration = 0.001 seconds
 - PASS - [littlefs.test_util_path_extend_overrun] duration = 0.001 seconds
 - PASS - [littlefs.test_util_path_extend_up] duration = 0.001 seconds
 - PASS - [littlefs.test_util_path_init_base] duration = 0.001 seconds
 - PASS - [littlefs.test_util_path_init_extended] duration = 0.001 seconds
 - PASS - [littlefs.test_util_path_init_overrun] duration = 0.001 seconds
```

Finally, I created a benchmark small test : 
https://gist.github.com/moonlight83340/600b05d7db1ea8307ff992a949181c60
I compare `scsat1-fsw` driver (`sc-qspi.c` + `spi-nor.c`) against `a1-sample` (`sc_qspi_nor.c`).

`scsat1-fsw` driver (`sc-qspi.c` + `spi-nor.c`) 
```
*** Booting Zephyr OS build v4.2.0-2936-g0a339a2d7b6d ***
SC-OBC Module A1 Bootloader Ver 1.0.0
Load from Configuration Memory address : 0x01a00000
*** Booting Zephyr OS build v3.7.0-177-g30af4b26968c ***
[00:00:02.005,000] <inf> bench: ========================================
[00:00:02.011,000] <inf> bench:    FLASH BENCHMARK (Size: 128 KB)
[00:00:02.018,000] <inf> bench: ========================================
[00:00:02.026,000] <inf> bench: Device: s25fl256l1@0
[00:00:02.032,000] <inf> bench: Starting Erase...
[00:00:02.542,000] <inf> bench: ERASE      :  504 ms | Speed:   253 KB/s
[00:00:02.550,000] <inf> bench: Starting Write...
[00:00:05.274,000] <inf> bench: WRITE      : 2720 ms | Speed:    47 KB/s
[00:00:05.281,000] <inf> bench: Starting Read...
[00:00:07.627,000] <inf> bench: READ       : 2341 ms | Speed:    54 KB/s
[00:00:07.634,000] <inf> bench: ========================================
```

 `a1-sample` (`sc_qspi_nor.c`)
```
*** Booting Zephyr OS build v4.2.0-2936-g0a339a2d7b6d ***
SC-OBC Module A1 Bootloader Ver 1.0.0
Load from Configuration Memory address : 0x01a00000
*** Booting Zephyr OS build sc-norflash-v1.0.0 ***
[00:00:02.001,000] <inf> bench: ========================================
[00:00:02.001,000] <inf> bench:    FLASH BENCHMARK (Size: 128 KB)
[00:00:02.001,000] <inf> bench: ========================================
[00:00:02.001,000] <inf> bench: Device: flash1
[00:00:02.001,000] <inf> bench: Starting Erase...
[00:00:02.518,000] <inf> bench: ERASE      :  517 ms | Speed:   247 KB/s
[00:00:02.520,000] <inf> bench: Starting Write...
[00:00:03.276,000] <inf> bench: WRITE      :  756 ms | Speed:   169 KB/s
[00:00:03.276,000] <inf> bench: Starting Read...
[00:00:03.842,000] <inf> bench: READ       :  566 ms | Speed:   226 KB/s
[00:00:03.842,000] <inf> bench: ========================================
```



